### PR TITLE
[Aaudio] :wrench: Use last Aaudio implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/
+.idea
 .DS_Store
 /build
 /captures

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:25.0.1'
 
-    //compile project(':soundsystem')
-    releaseCompile project(path: ':soundsystem', configuration: 'release')
-    debugCompile project(path: ':soundsystem', configuration: 'debug')
+    compile project(':soundsystem')
+    //releaseCompile project(path: ':soundsystem', configuration: 'release')
+    //debugCompile project(path: ':soundsystem', configuration: 'debug')
 }

--- a/app/src/main/java/fr/bowserf/testsoundsystem/MainActivity.java
+++ b/app/src/main/java/fr/bowserf/testsoundsystem/MainActivity.java
@@ -62,7 +62,7 @@ public class MainActivity extends AppCompatActivity {
         final AudioFeaturesManager audioFeaturesManager = AudioFeaturesManager.init(this);
 
         mSoundSystem = SoundSystem.getInstance();
-        if(!mSoundSystem.isSoundSystemInit()) {
+        if (!mSoundSystem.isSoundSystemInit()) {
             mSoundSystem.initSoundSystem(
                     audioFeaturesManager.getSampleRate(),
                     audioFeaturesManager.getFramesPerBuffer());
@@ -72,7 +72,7 @@ public class MainActivity extends AppCompatActivity {
 
         attachToListeners();
 
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             displayAvailableAudioCodecs();
         }
     }
@@ -96,11 +96,11 @@ public class MainActivity extends AppCompatActivity {
         // tv percentage displayed
         mTvPercentageDisplayed = (TextView) findViewById(R.id.tv_percentage_displayed);
 
-        if(mSoundSystem.isLoaded()){
+        if (mSoundSystem.isLoaded()) {
             mTogglePlayPause.setEnabled(true);
             mToggleStop.setEnabled(true);
             mBtnExtractFile.setEnabled(false);
-        }else{
+        } else {
             mBtnExtractFile.setEnabled(true);
             mTogglePlayPause.setEnabled(false);
             mToggleStop.setEnabled(false);
@@ -108,7 +108,7 @@ public class MainActivity extends AppCompatActivity {
 
         mTogglePlayPause.setChecked(mSoundSystem.isPlaying());
 
-        mSpectrum = (SpectrumGLSurfaceView)findViewById(R.id.spectrum);
+        mSpectrum = (SpectrumGLSurfaceView) findViewById(R.id.spectrum);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onDestroy() {
-        if(!isChangingConfigurations()) {
+        if (!isChangingConfigurations()) {
             detachListeners();
             mSoundSystem.release();
         }
@@ -143,21 +143,21 @@ public class MainActivity extends AppCompatActivity {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void displayAvailableAudioCodecs(){
-        final TextView tvAvailableCodecs = (TextView)findViewById(R.id.tv_available_codecs);
+    private void displayAvailableAudioCodecs() {
+        final TextView tvAvailableCodecs = (TextView) findViewById(R.id.tv_available_codecs);
 
         final MediaCodecList mediaCodecList = new MediaCodecList(MediaCodecList.REGULAR_CODECS);
         final MediaCodecInfo[] codecInfos = mediaCodecList.getCodecInfos();
         final StringBuilder stringBuilder = new StringBuilder();
         for (final MediaCodecInfo codecInfo : codecInfos) {
-            if(!codecInfo.isEncoder()) {
+            if (!codecInfo.isEncoder()) {
                 boolean isAudioCodec = false;
                 for (final String type : codecInfo.getSupportedTypes()) {
                     if (type.contains("audio/")) {
                         isAudioCodec = true;
                     }
                 }
-                if(isAudioCodec){
+                if (isAudioCodec) {
                     stringBuilder.append(codecInfo.getName()).append(" : \n");
                     for (final String type : codecInfo.getSupportedTypes()) {
                         if (type.contains("audio/")) {

--- a/app/src/main/java/fr/bowserf/testsoundsystem/utils/FindTrackManager.java
+++ b/app/src/main/java/fr/bowserf/testsoundsystem/utils/FindTrackManager.java
@@ -37,7 +37,7 @@ public class FindTrackManager {
         final int numberMusicFiles = musicCursorExtern.getCount();
         if (numberMusicFiles == 0) {
             return null;
-        }else if(numberMusicFiles == mCount -1){
+        } else if (numberMusicFiles == mCount - 1) {
             mCount = -1;
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.4.0-alpha6'
-        classpath 'com.android.tools.build:gradle-experimental:0.10.0-alpha6'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle-experimental:0.11.0-alpha3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -24,9 +24,8 @@ task clean(type: Delete) {
 }
 
 ext {
-    compileSdkVersion = 25
-    buildToolsVersion = "25.0.1"
-    minSdkVersion = 25
-    targetSdkVersion = 25
-    useAAudio = true
+    compileSdkVersion = 26
+    buildToolsVersion = "26.0.0"
+    minSdkVersion = 26
+    targetSdkVersion = 26
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 10 22:46:21 CEST 2017
+#Tue Jun 13 09:14:21 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip

--- a/nativesoundsystem/build.gradle
+++ b/nativesoundsystem/build.gradle
@@ -3,26 +3,24 @@ apply plugin: 'com.android.model.native'
 model {
     android {
         compileSdkVersion rootProject.ext.compileSdkVersion
-
-        // This allows the library project to be built in debug mode, so we can actually debug it
-        publishNonDefault true
     }
 
     android.ndk {
         moduleName = "soundsystem"
-        ldLibs.addAll(["log", "android", "OpenSLES"])
+        ldLibs.addAll(["log", "android", "atomic", "OpenSLES"])
         abiFilters.addAll(["armeabi", "armeabi-v7a", "x86"])
         CFlags.add("-std=c99")
         cppFlags.add("-std=c++11")
 
-        platformVersion = rootProject.ext.minSdkVersion //same as minSdkVersion.apiLevel for better compatibility
-        if(rootProject.ext.useAAudio) {
+        platformVersion = rootProject.ext.minSdkVersion
+        //same as minSdkVersion.apiLevel for better compatibility
+        if (rootProject.ext.minSdkVersion >= 26) {
             ldLibs.addAll(["mediandk", "aaudio"])
             cppFlags.addAll(["-DAAUDIO", "-DMEDIACODEC_EXTRACTOR"])
             CFlags.addAll(["-DAAUDIO", "-DMEDIACODEC_EXTRACTOR"])
-            platformVersion = 26 // AAudio headers are only available with API 26 but sdk 26 is not yet available
+            // AAudio headers are only available with API 26 but sdk 26 is not yet available
             stl "c++_static" // to access to 'thread' header, we did gnustl_static or c++_static
-        }else if(rootProject.ext.minSdkVersion >= 24) {
+        } else if (rootProject.ext.minSdkVersion >= 24) {
             ldLibs.addAll(["mediandk"])
             cppFlags.addAll(["-DMEDIACODEC_EXTRACTOR"])
             CFlags.addAll(["-DMEDIACODEC_EXTRACTOR"])
@@ -31,7 +29,7 @@ model {
             cppFlags.addAll(["-DFLOAT_PLAYER"])
             CFlags.addAll(["-DFLOAT_PLAYER"])
             stl "stlport_static"
-        }else{
+        } else {
             stl "stlport_static"
         }
     }

--- a/nativesoundsystem/src/main/jni/aaudio/AAudioCommon.cpp
+++ b/nativesoundsystem/src/main/jni/aaudio/AAudioCommon.cpp
@@ -19,42 +19,37 @@
 #include "AAudioCommon.h"
 
 static const int32_t audioFormatEnum[] = {
-    AAUDIO_FORMAT_INVALID,
-    AAUDIO_FORMAT_UNSPECIFIED,
-    AAUDIO_FORMAT_PCM_I16,
-    AAUDIO_FORMAT_PCM_FLOAT,
-    AAUDIO_FORMAT_PCM_I8_24,
-    AAUDIO_FORMAT_PCM_I32
+        AAUDIO_FORMAT_INVALID,
+        AAUDIO_FORMAT_UNSPECIFIED,
+        AAUDIO_FORMAT_PCM_I16,
+        AAUDIO_FORMAT_PCM_FLOAT
 };
-static const int32_t audioFormatCount = sizeof(audioFormatEnum)/
+static const int32_t audioFormatCount = sizeof(audioFormatEnum) /
                                         sizeof(audioFormatEnum[0]);
 
 static const uint32_t sampleFormatBPP[] = {
-    0xffff,
-    0xffff,
-    16, //I16
-    32, //FLOAT
-    24, //I8_24
-    32,
+        0xffff,
+        0xffff,
+        16, //I16
+        32 //FLOAT
 };
 
-uint16_t SampleFormatToBpp(aaudio_audio_format_t format) {
+uint16_t SampleFormatToBpp(aaudio_format_t format) {
     for (int32_t i = 0; i < audioFormatCount; ++i) {
-      if (audioFormatEnum[i] == format)
-        return sampleFormatBPP[i];
+        if (audioFormatEnum[i] == format)
+            return sampleFormatBPP[i];
     }
     return 0xffff;
 }
 
-static const char * audioFormatStr[] = {
-    "AAUDIO_FORMAT_INVALID", // = -1,
-    "AAUDIO_FORMAT_UNSPECIFIED", // = 0,
-    "AAUDIO_FORMAT_PCM_I16",
-    "AAUDIO_FORMAT_PCM_FLOAT",
-    "AAUDIO_FORMAT_PCM_I8_24",
-    "AAUDIO_FORMAT_PCM_I32",
+static const char *audioFormatStr[] = {
+        "AAUDIO_FORMAT_INVALID", // = -1,
+        "AAUDIO_FORMAT_UNSPECIFIED", // = 0,
+        "AAUDIO_FORMAT_PCM_I16",
+        "AAUDIO_FORMAT_PCM_FLOAT"
 };
-const char* FormatToString(aaudio_audio_format_t format) {
+
+const char *FormatToString(aaudio_format_t format) {
     for (int32_t i = 0; i < audioFormatCount; ++i) {
         if (audioFormatEnum[i] == format)
             return audioFormatStr[i];
@@ -62,7 +57,7 @@ const char* FormatToString(aaudio_audio_format_t format) {
     return "UNKNOW_AUDIO_FORMAT";
 }
 
-void PrintAudioStreamInfo(const AAudioStream * stream) {
+void PrintAudioStreamInfo(const AAudioStream *stream) {
 #define STREAM_CALL(c) AAudioStream_##c((AAudioStream*)stream)
     LOGI("StreamID: %p", stream);
 
@@ -73,17 +68,17 @@ void PrintAudioStreamInfo(const AAudioStream * stream) {
     LOGI("SampleRate: %d", STREAM_CALL(getSampleRate));
     LOGI("SamplesPerFrame: %d", STREAM_CALL(getSamplesPerFrame));
     LOGI("DeviceId: %d", STREAM_CALL(getDeviceId));
-    LOGI("Format: %s",  FormatToString(STREAM_CALL(getFormat)));
+    LOGI("Format: %s", FormatToString(STREAM_CALL(getFormat)));
     LOGI("SharingMode: %s", (STREAM_CALL(getSharingMode)) == AAUDIO_SHARING_MODE_EXCLUSIVE ?
-             "execlusive mode" : "sharing mode");
-    aaudio_direction_t  dir = STREAM_CALL(getDirection);
+                            "execlusive mode" : "sharing mode");
+    aaudio_direction_t dir = STREAM_CALL(getDirection);
     LOGI("Direction: %d", dir);
     if (dir == AAUDIO_DIRECTION_OUTPUT) {
-        LOGI("FramesReadByDevice: %d", (int32_t)STREAM_CALL(getFramesRead));
-        LOGI("FramesWriteByApp: %d", (int32_t)STREAM_CALL(getFramesWritten));
+        LOGI("FramesReadByDevice: %d", (int32_t) STREAM_CALL(getFramesRead));
+        LOGI("FramesWriteByApp: %d", (int32_t) STREAM_CALL(getFramesWritten));
     } else {
-        LOGI("FramesReadByApp: %d", (int32_t)STREAM_CALL(getFramesRead));
-        LOGI("FramesWriteByDevice: %d", (int32_t)STREAM_CALL(getFramesWritten));
+        LOGI("FramesReadByApp: %d", (int32_t) STREAM_CALL(getFramesRead));
+        LOGI("FramesWriteByDevice: %d", (int32_t) STREAM_CALL(getFramesWritten));
     }
 #undef SREAM_CALL
 }

--- a/nativesoundsystem/src/main/jni/aaudio/AAudioCommon.h
+++ b/nativesoundsystem/src/main/jni/aaudio/AAudioCommon.h
@@ -25,15 +25,16 @@
 /*
  * Audio Sample Controls...
  */
-#define AUDIO_SAMPLE_CHANNELS               2
+#define AUDIO_SAMPLE_CHANNELS 2
 
-uint16_t SampleFormatToBpp(aaudio_audio_format_t format);
+uint16_t SampleFormatToBpp(aaudio_format_t format);
+
 /*
  * GetSystemTicks(void):  return the time in micro sec
  */
 __inline__ uint64_t GetSystemTicks(void) {
     struct timeval Time;
-    gettimeofday( &Time, NULL );
+    gettimeofday(&Time, NULL);
 
     return (static_cast<uint64_t>(1000000) * Time.tv_sec + Time.tv_usec);
 }
@@ -43,7 +44,8 @@ __inline__ uint64_t GetSystemTicks(void) {
  */
 //#define ENABLE_LOG  1
 
-void PrintAudioStreamInfo(const AAudioStream * stream);
+void PrintAudioStreamInfo(const AAudioStream *stream);
+
 #endif // AAUDIO_AUDIO_COMMON_H
 
 #endif

--- a/nativesoundsystem/src/main/jni/aaudio/AAudioManager.h
+++ b/nativesoundsystem/src/main/jni/aaudio/AAudioManager.h
@@ -18,34 +18,37 @@
  * This Sample's Engine Structure
  */
 struct AAudioEngine {
-    int32_t     sampleRate_;
-    uint16_t     sampleChannels_;
-    uint16_t     bitsPerSample_;
-    aaudio_audio_format_t sampleFormat_;
+    uint32_t sampleRate_;
+    uint16_t sampleChannels_;
+    uint16_t bitsPerSample_;
+    aaudio_format_t sampleFormat_;
 
-    SoundSystem* soundSystem_;
+    SoundSystem *soundSystem_;
 
     AAudioStream *playStream_;
-    bool   requestStop_;
-    bool   playAudio_;
+    bool requestStop_;
+    bool playAudio_;
 
     int playPosition_;
 
+    int32_t underRunCount_;
+    int32_t bufSizeInFrames_;
+    int32_t framesPerBurst_;
+    int32_t defaultBufSizeInFrames_;
 };
 static AAudioEngine engine;
 
-bool TunePlayerForLowLatency(AAudioStream* stream);
-
-class AAudioManager{
+class AAudioManager {
 public:
 
-    bool createEngine(SoundSystem* soundSystem);
+    bool createEngine(SoundSystem *soundSystem);
+
     bool start();
+
     bool stop();
+
     void deleteEngine();
-
 };
-
 
 
 #endif //MINI_SOUND_SYSTEM_AAUDIOMANAGER_H

--- a/nativesoundsystem/src/main/jni/aaudio/headers/stream_builder.h
+++ b/nativesoundsystem/src/main/jni/aaudio/headers/stream_builder.h
@@ -24,42 +24,15 @@
 //Replace this include with NDK's AAudio.h when available
 #include <aaudio/AAudio.h>
 
+#define INVALID_AUDIO_PARAM 0
+
 class StreamBuilder {
-
 public:
-
-    StreamBuilder() :
-            sampleRate_(0),
-            samplesPerFrame_(0),
-            format_(AAUDIO_FORMAT_PCM_I16),
-            sharing_(AAUDIO_SHARING_MODE_SHARED),
-            direction_(AAUDIO_DIRECTION_OUTPUT),
-            stream_(nullptr) {
+    explicit StreamBuilder() {
         aaudio_result_t result = AAudio_createStreamBuilder(&builder_);
-        assert(result == AAUDIO_OK && builder_);
-    };
-
-    StreamBuilder(
-            int32_t samplesPerFrame,
-            aaudio_audio_format_t format,
-            aaudio_sharing_mode_t sharing,
-            aaudio_direction_t dir) :
-            sampleRate_(0),
-            samplesPerFrame_(samplesPerFrame),
-            format_(format),
-            sharing_(sharing),
-            direction_(dir) {
-        aaudio_result_t result = AAudio_createStreamBuilder(&builder_);
-        assert(result == AAUDIO_OK && builder_);
-
-        AAudioStreamBuilder_setSampleRate(builder_, sampleRate_);
-        AAudioStreamBuilder_setSamplesPerFrame(builder_, samplesPerFrame_);
-        AAudioStreamBuilder_setFormat(builder_, format_);
-        AAudioStreamBuilder_setSharingMode(builder_, sharing_);
-        AAudioStreamBuilder_setDirection(builder_, direction_);
-
-        result = AAudioStreamBuilder_openStream(builder_, &stream_);
-        assert(result == AAUDIO_OK && stream_);
+        if (result != AAUDIO_OK && !builder_) {
+            assert(false);
+        }
     }
 
     ~StreamBuilder() {
@@ -68,59 +41,43 @@ public:
         builder_ = nullptr;
     };
 
-    int32_t DeviceId(void) {
-        return stream_ ? AAudioStream_getDeviceId(stream_) : 0;
-    }
+    /*
+     * purposely left
+     *     deviceID
+     *     bufferSize
+     *     sampleRate
+     * as default, expecting that AAudio will pick up the right one for us
+     */
+    AAudioStream *CreateStream(
+            aaudio_format_t format,
+            int32_t samplesPerFrame,
+            aaudio_sharing_mode_t sharing,
+            aaudio_direction_t dir = AAUDIO_DIRECTION_OUTPUT,
+            int32_t sampleRate = INVALID_AUDIO_PARAM,
+            AAudioStream_dataCallback callback = nullptr,
+            void *userData = nullptr) {
 
-    void SampleRate(int32_t rate) { sampleRate_ = rate; }
-
-    int32_t SampleRate(void) const { return sampleRate_; }
-
-    void SamplesPerFrame(int32_t samplesPerFrame) { samplesPerFrame_ = samplesPerFrame; }
-
-    int32_t SamplesPerFrame(void) { return samplesPerFrame_; }
-
-    void Format(aaudio_audio_format_t format) { format_ = format; }
-
-    aaudio_audio_format_t Format(void) const { return format_; }
-
-    void SharingMode(aaudio_sharing_mode_t sharing) { sharing_ = sharing; }
-
-    aaudio_sharing_mode_t SharingMode(void) const { return sharing_; }
-
-    void Direction(aaudio_direction_t dir) { direction_ = dir; }
-
-    aaudio_direction_t Direction(void) const { return direction_; }
-
-    int32_t BufferCapacity(void) {
-        return stream_
-               ? AAudioStream_getBufferCapacityInFrames(stream_)
-               : 0;
-    }
-
-    AAudioStream *Stream(void) {
-        if (!stream_) {
-            AAudioStreamBuilder_setSampleRate(builder_, sampleRate_);
-            AAudioStreamBuilder_setSamplesPerFrame(builder_, samplesPerFrame_);
-            AAudioStreamBuilder_setFormat(builder_, format_);
-            AAudioStreamBuilder_setSharingMode(builder_, sharing_);
-            AAudioStreamBuilder_setDirection(builder_, direction_);
-            aaudio_result_t result = AAudioStreamBuilder_openStream(builder_, &stream_);
-            assert(stream_ && result == AAUDIO_OK);
+        AAudioStreamBuilder_setFormat(builder_, format);
+        AAudioStreamBuilder_setSharingMode(builder_, sharing);
+        AAudioStreamBuilder_setDirection(builder_, dir);
+        AAudioStreamBuilder_setSampleRate(builder_, sampleRate);
+        AAudioStreamBuilder_setSamplesPerFrame(builder_, samplesPerFrame);
+        if (sampleRate != INVALID_AUDIO_PARAM) {
+            AAudioStreamBuilder_setSampleRate(builder_, sampleRate);
         }
-        return stream_;
+        AAudioStreamBuilder_setDataCallback(builder_, callback, userData);
+
+        AAudioStream *stream;
+        aaudio_result_t result = AAudioStreamBuilder_openStream(builder_, &stream);
+        if (result != AAUDIO_OK) {
+            assert(false);
+            stream = nullptr;
+        }
+        return stream;
     }
 
 private:
-
     AAudioStreamBuilder *builder_;
-    int32_t sampleRate_;
-    int32_t samplesPerFrame_;
-    aaudio_audio_format_t format_;
-    aaudio_sharing_mode_t sharing_;
-    aaudio_direction_t direction_;
-    AAudioStream *stream_;
-
 };
 
 #endif //AAUDIO_STREAM_BIULDER_H

--- a/nativesoundsystem/src/main/jni/bridge/SoundsystemEntrypoint.cpp
+++ b/nativesoundsystem/src/main/jni/bridge/SoundsystemEntrypoint.cpp
@@ -1,9 +1,9 @@
 #include "SoundsystemEntrypoint.h"
 
 void Java_fr_bowserf_soundsystem_SoundSystem_native_1init_1soundsystem(JNIEnv *env,
-                                                               jclass jclass1,
-                                                               jint sample_rate,
-                                                               jint frames_per_buf) {
+                                                                       jclass jclass1,
+                                                                       jint sample_rate,
+                                                                       jint frames_per_buf) {
     _soundSystemCallback = new SoundSystemCallback(env, jclass1);
 
     _soundSystem = new SoundSystem(_soundSystemCallback, sample_rate, frames_per_buf);
@@ -19,14 +19,14 @@ void Java_fr_bowserf_soundsystem_SoundSystem_native_1init_1soundsystem(JNIEnv *e
 }
 
 jboolean Java_fr_bowserf_soundsystem_SoundSystem_native_1is_1soundsystem_1init(JNIEnv *env,
-                                                                       jclass jclass1) {
-    return (jboolean)isSoundSystemInit();
+                                                                               jclass jclass1) {
+    return (jboolean) isSoundSystemInit();
 }
 
 void Java_fr_bowserf_soundsystem_SoundSystem_native_1load_1file(JNIEnv *env,
-                                                               jclass jclass1,
-                                                               jstring filePath) {
-    if(!isSoundSystemInit()){
+                                                                jclass jclass1,
+                                                                jstring filePath) {
+    if (!isSoundSystemInit()) {
         return;
     }
 #ifdef MEDIACODEC_EXTRACTOR
@@ -38,15 +38,16 @@ void Java_fr_bowserf_soundsystem_SoundSystem_native_1load_1file(JNIEnv *env,
     _soundSystem->initAudioPlayer();
 }
 
-void Java_fr_bowserf_soundsystem_SoundSystem_native_1play(JNIEnv *env, jclass jclass1, jboolean play){
-    if(!isSoundSystemInit()){
+void
+Java_fr_bowserf_soundsystem_SoundSystem_native_1play(JNIEnv *env, jclass jclass1, jboolean play) {
+    if (!isSoundSystemInit()) {
         return;
     }
 
 #ifdef AAUDIO
-    if(play){
+    if (play) {
         _aaudio_manager->start();
-    }else{
+    } else {
         _aaudio_manager->stop();
     }
 #else
@@ -54,22 +55,22 @@ void Java_fr_bowserf_soundsystem_SoundSystem_native_1play(JNIEnv *env, jclass jc
 #endif
 }
 
-jboolean Java_fr_bowserf_soundsystem_SoundSystem_native_1is_1playing(JNIEnv *env, jclass jclass1){
-    if(!isSoundSystemInit()){
+jboolean Java_fr_bowserf_soundsystem_SoundSystem_native_1is_1playing(JNIEnv *env, jclass jclass1) {
+    if (!isSoundSystemInit()) {
         return JNI_FALSE;
     }
-    return (jboolean)_soundSystem->isPlaying();
+    return (jboolean) _soundSystem->isPlaying();
 }
 
-jboolean Java_fr_bowserf_soundsystem_SoundSystem_native_1is_1loaded(JNIEnv *env, jclass jclass1){
-    if(!isSoundSystemInit()){
+jboolean Java_fr_bowserf_soundsystem_SoundSystem_native_1is_1loaded(JNIEnv *env, jclass jclass1) {
+    if (!isSoundSystemInit()) {
         return JNI_FALSE;
     }
-    return (jboolean)_soundSystem->isLoaded();
+    return (jboolean) _soundSystem->isLoaded();
 }
 
 void Java_fr_bowserf_soundsystem_SoundSystem_native_1stop(JNIEnv *env, jclass jclass1) {
-    if(!isSoundSystemInit()){
+    if (!isSoundSystemInit()) {
         return;
     }
     _soundSystem->stop();
@@ -78,54 +79,63 @@ void Java_fr_bowserf_soundsystem_SoundSystem_native_1stop(JNIEnv *env, jclass jc
 #endif
 }
 
-void Java_fr_bowserf_soundsystem_SoundSystem_native_1extract_1and_1play(JNIEnv *env, jobject obj, jstring filePath){
-    if(!isSoundSystemInit()){
+void Java_fr_bowserf_soundsystem_SoundSystem_native_1extract_1and_1play(
+        JNIEnv *env,
+        jobject obj,
+        jstring filePath) {
+    if (!isSoundSystemInit()) {
         return;
     }
     _soundSystem->extractAndPlayDirectly(dataLocatorFromURLString(env, filePath));
 }
 
-void Java_fr_bowserf_soundsystem_SoundSystem_native_1extract_1from_1assets_1and_1play(JNIEnv *env, jobject obj, jobject assetManager, jstring filename){
-    if(!isSoundSystemInit()){
+void Java_fr_bowserf_soundsystem_SoundSystem_native_1extract_1from_1assets_1and_1play(
+        JNIEnv *env,
+        jobject obj,
+        jobject assetManager,
+        jstring filename) {
+    if (!isSoundSystemInit()) {
         return;
     }
     SLDataLocator_AndroidFD locator = getTrackFromAsset(env, assetManager, filename);
     _soundSystem->extractAndPlayDirectly(&locator);
 }
 
-void Java_fr_bowserf_soundsystem_SoundSystem_native_1release_1soundsystem(JNIEnv *env, jclass jclass1) {
+void Java_fr_bowserf_soundsystem_SoundSystem_native_1release_1soundsystem(
+        JNIEnv *env, jclass jclass1) {
     if (_soundSystem != nullptr) {
         delete _soundSystem;
         _soundSystem = nullptr;
     }
 
 #ifdef MEDIACODEC_EXTRACTOR
-    if(_extractorNougat!= nullptr) {
+    if (_extractorNougat != nullptr) {
         delete _extractorNougat;
         _extractorNougat = nullptr;
     }
 #endif
 
 #ifdef AAUDIO
-    if(_aaudio_manager != nullptr){
+    if (_aaudio_manager != nullptr) {
         delete _aaudio_manager;
         _aaudio_manager = nullptr;
     }
 #endif
 }
 
-jshortArray Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data(JNIEnv *env, jclass jclass1) {
-    if(!isSoundSystemInit()){
+jshortArray
+Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data(JNIEnv *env, jclass jclass1) {
+    if (!isSoundSystemInit()) {
         return nullptr;
     }
-    unsigned int length = _soundSystem->getTotalNumberFrames()/40;
-    AUDIO_HARDWARE_SAMPLE_TYPE* tmpExtractedData = _soundSystem->getExtractedData();
+    unsigned int length = _soundSystem->getTotalNumberFrames() / 40;
+    AUDIO_HARDWARE_SAMPLE_TYPE *tmpExtractedData = _soundSystem->getExtractedData();
 
 #ifdef FLOAT_PLAYER
     short* extractedData = (short*)calloc(length, sizeof(short));
     convertFloatDataToShort(tmpExtractedData, length, extractedData);
 #else
-    short* extractedData = tmpExtractedData;
+    short *extractedData = tmpExtractedData;
 #endif
 
     jshortArray jExtractedData = env->NewShortArray(length);
@@ -136,19 +146,20 @@ jshortArray Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data
     return jExtractedData;
 }
 
-jshortArray Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data_1mono(JNIEnv *env, jclass jclass1) {
-    if(!isSoundSystemInit()){
+jshortArray Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data_1mono(JNIEnv *env,
+                                                                                       jclass jclass1) {
+    if (!isSoundSystemInit()) {
         return nullptr;
     }
 
-    AUDIO_HARDWARE_SAMPLE_TYPE* tmpExtractedData = _soundSystem->getExtractedDataMono();
-    unsigned int length = _soundSystem->getTotalNumberFrames()/2;
+    AUDIO_HARDWARE_SAMPLE_TYPE *tmpExtractedData = _soundSystem->getExtractedDataMono();
+    unsigned int length = _soundSystem->getTotalNumberFrames() / 2;
 
 #ifdef FLOAT_PLAYER
     short* extractedData = (short*)calloc(length, sizeof(short));
     convertFloatDataToShort(tmpExtractedData, length, extractedData);
 #else
-    short* extractedData = tmpExtractedData;
+    short *extractedData = tmpExtractedData;
 #endif
 
     jshortArray jExtractedData = env->NewShortArray(length);
@@ -159,15 +170,15 @@ jshortArray Java_fr_bowserf_soundsystem_SoundSystem_native_1get_1extracted_1data
     return jExtractedData;
 }
 
-SLDataLocator_AndroidFD getTrackFromAsset(JNIEnv *env, jobject assetManager, jstring filename){
+SLDataLocator_AndroidFD getTrackFromAsset(JNIEnv *env, jobject assetManager, jstring filename) {
     // convert Java string to UTF-8
     const char *utf8 = env->GetStringUTFChars(filename, NULL);
     assert(NULL != utf8);
 
     // use asset manager to open asset by filename
-    AAssetManager* mgr = AAssetManager_fromJava(env, assetManager);
+    AAssetManager *mgr = AAssetManager_fromJava(env, assetManager);
     assert(NULL != mgr);
-    AAsset* asset = AAssetManager_open(mgr, utf8, AASSET_MODE_UNKNOWN);
+    AAsset *asset = AAssetManager_open(mgr, utf8, AASSET_MODE_UNKNOWN);
 
     // release the Java string and UTF-8
     env->ReleaseStringUTFChars(filename, utf8);
@@ -183,8 +194,8 @@ SLDataLocator_AndroidFD getTrackFromAsset(JNIEnv *env, jobject assetManager, jst
     return loc_fd;
 }
 
-bool isSoundSystemInit(){
-    if(_soundSystem == NULL){
+bool isSoundSystemInit() {
+    if (_soundSystem == NULL) {
         LOGE("_soundSystem is not initialize");
         return false;
     }
@@ -201,12 +212,12 @@ SLDataLocator_URI *dataLocatorFromURLString(JNIEnv *env, jstring fileURLString) 
     return fileLoc;
 }
 
-void convertFloatDataToShort(float* src, unsigned int length, short* dst){
-    for(int i = 0 ; i < length ; i++){
+void convertFloatDataToShort(float *src, unsigned int length, short *dst) {
+    for (int i = 0; i < length; i++) {
         float tmp = src[i];
         if (tmp > 1.f) {
             tmp = 1.f;
-        }else if (tmp < -1.f){
+        } else if (tmp < -1.f) {
             tmp = -1.f;
         }
         dst[i] = tmp * SHRT_MAX;

--- a/soundsystem/build.gradle
+++ b/soundsystem/build.gradle
@@ -9,9 +9,6 @@ model {
             minSdkVersion.apiLevel rootProject.ext.minSdkVersion
             targetSdkVersion.apiLevel rootProject.ext.targetSdkVersion
         }
-
-        // This allows the library project to be built in debug mode, so we can actually debug it
-        publishNonDefault true
     }
 
     android.sources {


### PR DESCRIPTION
[Aaudio] :wrench: Use last Aaudio implementation with `aaudio_data_callback_result_t`.

<b>Note:</b> `AAudioStream_write()` still returns an `AAUDIO_ERROR_INVALID_STATE` because the stream_state is still <b>starting</b> and not <b>started</b>. Same issue on the Google sample.
Even with this error, the sound is good.

Some links: 
* Stream lifecycle [here](https://developer.android.com/ndk/guides/images/aaudio-lifecycle.png)
* On the google code, [here](https://github.com/googlesamples/android-audio-high-performance/blob/cb3eac5623800865bac811e5a06a809624c61fd1/aaudio/echo/src/main/cpp/audio_main.cpp#L101), if you check `AAudio_convertStreamStateToText(AAudioStream_getState(eng->playStream_))`, you will have `AAUDIO_STREAM_STATE_STARTING`...